### PR TITLE
Drop reference to moved project

### DIFF
--- a/lib/Element.php
+++ b/lib/Element.php
@@ -15,7 +15,7 @@ use XMLReader;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 interface Element extends XmlSerializable, XmlDeserializable {
 

--- a/lib/Element/Base.php
+++ b/lib/Element/Base.php
@@ -13,7 +13,7 @@ use Sabre\Xml;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Base implements Xml\Element {
 

--- a/lib/Element/Cdata.php
+++ b/lib/Element/Cdata.php
@@ -17,7 +17,7 @@ use
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Cdata implements Xml\XmlSerializable
 {

--- a/lib/Element/Elements.php
+++ b/lib/Element/Elements.php
@@ -29,7 +29,7 @@ use Sabre\Xml;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Elements implements Xml\Element {
 

--- a/lib/Element/KeyValue.php
+++ b/lib/Element/KeyValue.php
@@ -30,7 +30,7 @@ use Sabre\Xml;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class KeyValue implements Xml\Element {
 

--- a/lib/Element/Uri.php
+++ b/lib/Element/Uri.php
@@ -19,7 +19,7 @@ use LogicException;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Uri implements Xml\Element {
 

--- a/lib/LibXMLException.php
+++ b/lib/LibXMLException.php
@@ -12,7 +12,7 @@ use
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class LibXMLException extends ParseException {
 

--- a/lib/ParseException.php
+++ b/lib/ParseException.php
@@ -10,7 +10,7 @@ use
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class ParseException extends Exception {
 

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -15,7 +15,7 @@ use XMLReader;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Reader extends XMLReader {
 

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -11,7 +11,7 @@ namespace Sabre\Xml;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Service {
 

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -28,7 +28,7 @@ use
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Writer extends XMLWriter {
 

--- a/lib/XmlDeserializable.php
+++ b/lib/XmlDeserializable.php
@@ -10,7 +10,7 @@ use XMLReader;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 interface XmlDeserializable {
 

--- a/tests/Sabre/XML/Element/Eater.php
+++ b/tests/Sabre/XML/Element/Eater.php
@@ -10,7 +10,7 @@ use Sabre\Xml;
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
- * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ * @license http://sabre.io/license/ Modified BSD License
  */
 class Eater implements Xml\Element {
 


### PR DESCRIPTION
Hi Evert,

Please note that you may wish to simply drop the copyright notice from the [generic license](http://sabre.io/license/), or at least update the last year there too.