### PR TITLE
Prevent eternal loop by ensuring that no libxml errors with level [LIBXML_ERR_FATAL]  have occurred

### DIFF
--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -55,6 +55,7 @@ class Reader extends XMLReader {
      * This function will also disable the standard libxml error handler (which
      * usually just results in PHP errors), and throw exceptions instead.
      *
+     * @throws LibXMLException
      * @return array
      */
     function parse() {
@@ -76,10 +77,9 @@ class Reader extends XMLReader {
 
         if ($errors) {
             throw new LibXMLException($errors);
-        } else {
-            return $result;
         }
 
+        return $result;
     }
 
     /**
@@ -93,16 +93,14 @@ class Reader extends XMLReader {
      * If the $elementMap argument is specified, the existing elementMap will
      * be overridden while parsing the tree, and restored after this process.
      *
+     * @throws ParseException
      * @param array $elementMap
      * @return array|string
      */
     function parseInnerTree(array $elementMap = null) {
 
-        $previousDepth = $this->depth;
-
         $text = null;
         $elements = [];
-        $attributes = [];
 
         if ($this->nodeType === self::ELEMENT && $this->isEmptyElement) {
             // Easy!
@@ -255,7 +253,7 @@ class Reader extends XMLReader {
      * short keys. If they are defined on a different namespace, the attribute
      * name will be retured in clark-notation.
      *
-     * @return void
+     * @return array
      */
     function parseAttributes() {
 
@@ -281,22 +279,5 @@ class Reader extends XMLReader {
         return $attributes;
 
     }
-
-    /**
-     * @return bool
-     */
-    function isValidationEnabled()
-    {
-        return $this->validationEnabled;
-    }
-
-    /**
-     * @param bool $enable
-     */
-    function setValidationEnabled($enable = true)
-    {
-        $this->validationEnabled = $enable;
-    }
-
 
 }

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -21,9 +21,6 @@ class Reader extends XMLReader {
 
     use ContextStackTrait;
 
-    /** @var bool  */
-    protected $validationEnabled = false;
-
     /**
      * Returns the current nodename in clark-notation.
      *

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -38,7 +38,6 @@ class Reader extends XMLReader {
         }
 
         return '{' . $this->namespaceURI . '}' . $this->localName;
-
     }
 
     /**
@@ -111,12 +110,13 @@ class Reader extends XMLReader {
         }
 
 
-        // Really sorry about the silence operator, seems like I have no
-        // choice. See:
+        // Really sorry about the silence operator, seems like I have no choice. See:
         //
         // https://bugs.php.net/bug.php?id=64230
         if (!@$this->read()) return false;
 
+        // Check for internal libxml errors. We must abort when a fatal libxml error occurs.
+        // Not doing so will result in a eternal loop.
         while ($this->canContinue()) {
 
             switch ($this->nodeType) {
@@ -144,8 +144,8 @@ class Reader extends XMLReader {
         if (!is_null($elementMap)) {
             $this->popContext();
         }
-        return ($elements ? $elements : $text);
 
+        return ($elements ? $elements : $text);
     }
 
     /**
@@ -188,8 +188,8 @@ class Reader extends XMLReader {
                 $result .= $this->value;
             }
         }
-        return $result;
 
+        return $result;
     }
 
     /**

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -136,7 +136,7 @@ class Reader extends XMLReader {
                     throw new ParseException('We hit the end of the document prematurely. This likely means that some parser "eats" too many elements. Do not attempt to continue parsing.');
                 default :
                     // This prevents an eternal loop in case of a missing open tag.
-                    if(!$this->read()) {
+                    if (!$this->read()) {
                         throw new ParseException("Unable to parse invalid '{$this->localName}' node. The XML document is not valid.");
                         break 2; // Break out of invalid element
                     }
@@ -164,9 +164,9 @@ class Reader extends XMLReader {
     {
         // Check for errors. Normally there will be no error, so this should not have a big impact on performance.
         $errors = libxml_get_errors();
-        if(count($errors)) {
+        if (count($errors)) {
             /** @var \LibXMLError $error */
-            foreach($errors as $e) {
+            foreach ($errors as $e) {
                 if ($e->level === LIBXML_ERR_FATAL){
                     libxml_clear_errors();
                     throw new LibXMLException($errors);

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -135,11 +135,7 @@ class Reader extends XMLReader {
                 case self::NONE :
                     throw new ParseException('We hit the end of the document prematurely. This likely means that some parser "eats" too many elements. Do not attempt to continue parsing.');
                 default :
-                    // This prevents an eternal loop in case of a missing open tag.
-                    if (!$this->read()) {
-                        throw new ParseException("Unable to parse invalid '{$this->localName}' node. The XML document is not valid.");
-                        break 2; // Break out of invalid element
-                    }
+                    $this->read();
                     break;
             }
 

--- a/tests/Sabre/Xml/ParserTest.php
+++ b/tests/Sabre/Xml/ParserTest.php
@@ -1,0 +1,560 @@
+<?php
+namespace Sabre\Xml;
+
+
+class ParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Simple test to check if the parser is able to parse documents under normal circumstances.
+     * Check if the result is as expected.
+     * - Use multiple schema's and multiple namespaces
+     * - Test attributes
+     * - Test elements with child nodes
+     * - Test element without child nodes and attributes ( <movie:bestseller /> )
+     */
+    public function testParserShouldSucceed()
+    {
+        $reader = new Reader();
+        $reader->XML($this->xmlValidDocument);
+        $result = $reader->parse();
+        $this->assertNotEmpty($result);
+        $result = $result['value'];
+
+        // Validate store name
+        $this->assertEquals('Awesome Shop Inc.', $result[0]['value'], "The store name is not valid.");
+
+        // Validate customers
+        $customers = $result[1]['value'];
+        $this->assertInternalType('array', $customers, "Array of customers expected.");
+        $this->assertCount(2, $customers, "There should be 2 customers");
+
+        // Validate customer 1
+        $this->assertNotEmpty($customers[0]['attributes']['code'], "Failed to parse code attribute of customer 1.");
+        $customer1 = $customers[0]['value'];
+        $this->assertEquals('K.M. Johnson', $customer1[0]['value']);
+        $this->assertEquals(33, $customer1[1]['value']);
+        $this->assertEquals('male', $customer1[2]['value']);
+        $books = $customer1[3]['value'];
+        $this->assertNotEmpty($books[0]['attributes']['code'], "The book element should have a code attribute.");
+        $book1 = $books[0]['value'];
+        $this->assertEquals('Boring story oversees', $book1[0]['value'], "Failed to parse the book title.");
+        $this->assertEquals(1988, $book1[1]['value'], "Failed to parse the published year.");
+        $this->assertEquals('roman', $book1[2]['value'], "Failed to parse the books genre.");
+        $author = $book1[3]['value'];
+        $this->assertEquals('M.R. Lame', $author[0]['value'], "Failed to parse the authors name.");
+        $this->assertEquals(22, $author[1]['value'], "Failed to parse the authors age.");
+        $this->assertEquals('male', $author[2]['value'], "Failed to parse the authors gender.");
+        $publisher = $book1[4]['value'];
+        $this->assertEquals('C.A. Wulff', $publisher[0]['value'], "Failed to parse the authors name.");
+        $this->assertEquals(44, $publisher[1]['value'], "Failed to parse the authors age.");
+        $this->assertEquals('female', $publisher[2]['value'], "Failed to parse the authors gender.");
+
+        // Validate customer 2
+        $this->assertNotEmpty($customers[1]['attributes']['code'], "Failed to parse code attribute of customer 2.");
+        $customer2 = $customers[1]['value'];
+        $this->assertEquals('L.O. Lolsson', $customer2[0]['value']);
+        $this->assertEquals(42, $customer2[1]['value']);
+        $this->assertEquals('female', $customer2[2]['value']);
+        $movies = $customer2[3]['value'];
+        $movie1 = $movies[0]['value'];
+        $this->assertEquals('Robin Hood and the wrath of the seven midgets.', $movie1[0]['value'], "Failed to parse the movie title.");
+        $this->assertEquals(1999, $movie1[1]['value'], "Failed to parse the movie year.");
+        $this->assertEquals('action', $movie1[2]['value'], "Failed to parse the movie genre.");
+        $actors = $movie1[3]['value'];
+        $actor1 = $actors[0]['value'];
+        $this->assertNotEmpty($actors[0]['attributes']['code'], "Failed to parse the actors code attribute.");
+        $this->assertEquals('O.K. Dude', $actor1[0]['value'], "Failed to parse the actors name.");
+        $this->assertEquals(22, $actor1[1]['value'], "Failed to parse the actors age");
+        $this->assertEquals('male', $actor1[2]['value'], "Failed to parse the actors gender.");
+        $this->assertArrayHasKey(4, $movie1, "Failed to parse the bestseller element. Note that this element has no contents and no attributes.");
+        $this->assertEquals("{http://sabre-test-set.com/Movie}bestseller", $movie1[4]['name'], "Failed to parse the bestseller element. Note that this element has no contents and no attributes.");
+    }
+    
+    /**
+     * Test if the schema validation works. When enabled each node is validated on the fly.
+     * By calling the parse method the whole tree processed and thus we should get an exception.
+     */
+    public function testParserShouldFailSchemaValidation()
+    {
+        $reader = new Reader();
+        $reader->XML($this->xmlWithInvalidNodes);
+        $this->assertTrue($reader->setSchema(__DIR__ . '/../../schema/Store.xsd'));
+        $failed = false;
+        try{
+            $reader->parse();
+        } catch(LibXMLException $e) {
+            $failed = true;
+        } finally {
+            $this->assertTrue($failed, 'The parser should have failed. The element "name3" is invalid.');
+        }
+    }
+
+    /**
+     * Ensure that the validation works for valid documents
+     */
+    public function testParserShouldPassSchemaValidation()
+    {
+        $reader = new Reader();
+        $reader->XML($this->xmlValidDocument);
+        $this->assertTrue($reader->setSchema(__DIR__ . '/../../schema/Store.xsd'));
+        $failed = false;
+        try{
+            $reader->parse();
+        } catch(LibXMLException $e) {
+            echo $e->getMessage() . PHP_EOL;
+            $failed = true;
+        } finally {
+            $this->assertFalse($failed, 'The parser should not have failed. The given XML is valid.');
+        }
+
+    }
+
+    /**
+     * Test if the parser can handle missing start tags.
+     */
+    public function testParserShouldHandleMissingStartTag()
+    {
+        // Register a tick function
+        register_tick_function(function(){
+            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed node...");
+        });
+
+        // Parse elements, use tick counter to break out of eternal loop and throw an exception
+        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        $reader = new Reader();
+        $reader->XML($this->xmlMissingStartNode);
+        $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
+        $trappedInEternalLoop = null;
+        try{
+            $reader->parse();
+        } catch(ParseException $e) {
+            $trappedInEternalLoop = false;
+        } catch(\LogicException $e) {
+            $trappedInEternalLoop = true;
+        }
+
+        $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+        $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
+    }
+
+    /**
+     * Test if the parser can handle missing end tags
+     */
+    public function testParserShouldHandleMissingEndTag()
+    {
+        // Register a tick function
+        register_tick_function(function(){
+            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed node...");
+        });
+
+        // Parse elements, use tick counter to break out of eternal loop and throw an exception
+        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        $reader = new Reader();
+        $reader->XML($this->xmlMissingEndNode);
+        $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
+        $trappedInEternalLoop = null;
+        try{
+            $reader->parse();
+        } catch(ParseException $e) {
+            $trappedInEternalLoop = false;
+        } catch(\LogicException $e) {
+            $trappedInEternalLoop = true;
+        } finally {
+            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
+        }
+    }
+
+    /**
+     * Test if the parser can handle malformed start tags
+     */
+    public function testParserShouldHandleMalformedStartTag()
+    {
+        // Register a tick function
+        register_tick_function(function(){
+            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed start tag...");
+        });
+
+        // Parse elements, use tick counter to break out of eternal loop and throw an exception
+        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        $reader = new Reader();
+        $reader->XML($this->xmlMalformedStartTag);
+        $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
+        $trappedInEternalLoop = null;
+        try{
+            $reader->parse();
+        } catch(ParseException $e) {
+            $trappedInEternalLoop = false;
+        } catch(\LogicException $e) {
+            $trappedInEternalLoop = true;
+        } finally {
+            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
+        }
+    }
+
+    /**
+     * Test if the parser can handle malformed end tags
+     */
+    public function testParserShouldHandleMalformedEndTag()
+    {
+        // Register a tick function
+        register_tick_function(function(){
+            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed end tag...");
+        });
+
+        // Parse elements, use tick counter to break out of eternal loop and throw an exception
+        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        $reader = new Reader();
+        //$reader->setValidationEnabled(true);
+        $reader->XML($this->xmlMalformedEndTag);
+        $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
+        $trappedInEternalLoop = null;
+        try{
+            $reader->parse();
+        } catch(ParseException $e) {
+            $trappedInEternalLoop = false;
+        } catch(\LogicException $e) {
+            $trappedInEternalLoop = true;
+        } finally {
+            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
+        }
+    }
+
+    /**
+     * Test if the parser can handle malformed end tags
+     */
+    public function testParserShouldHandleMalformedQuotes()
+    {
+        // Register a tick function
+        register_tick_function(function(){
+            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed quotes...");
+        });
+
+        // Parse elements, use tick counter to break out of eternal loop and throw an exception
+        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        $reader = new Reader();
+        $reader->XML($this->xmlMalformedQuotes);
+        $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
+        $trappedInEternalLoop = null;
+        try{
+            $reader->parse();
+        } catch(ParseException $e) {
+            $trappedInEternalLoop = false;
+        } catch(\LogicException $e) {
+            $trappedInEternalLoop = true;
+        } finally {
+            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
+        }
+    }
+
+
+    private $xmlMissingStartNode = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<s:store xmlns:s="http://sabre-test-set.com/Store"
+         xmlns:p="http://sabre-test-set.com/Person"
+         xmlns:b="http://sabre-test-set.com/Book"
+         xmlns:m="http://sabre-test-set.com/Movie">
+    <s:name>Awesome Shop Inc.</s:name>
+    <s:customers>
+        <p:customer code="dKje98">
+            <p:name>K.M. Johnson</p:name>
+            <p:age>33</p:age>
+            <p:gender>male</p:gender>
+            <p:books>
+                <b:book code="9488884889-33">
+                    <b:title>Boring story oversees</b:title>
+                    <b:year>1988</b:year>
+                    <b:genre>roman</b:genre>
+                    <b:author code="doj883jAA">
+                        <p:name>M.R. Lame</p:name>
+                        <p:gender>male</p:gender>
+                    </b:author>
+                        <p:name>C.A. Wulff</p:name>
+                        <p:age>44</p:age>
+                        <p:gender>female</p:gender>
+                    </b:publisher>
+                </b:book>
+            </p:books>
+        </p:customer>
+        <p:customer code="kdKK9o2L">
+            <p:name>L.O. Lolsson</p:name>
+            <p:age>42</p:age>
+            <p:gender>female</p:gender>
+            <p:movies>
+                <m:movie>
+                    <m:title>Robin Hood and the wrath of the seven midgets.</m:title>
+                    <m:year>1999</m:year>
+                    <m:genre>action</m:genre>
+                    <m:actors>
+                        <p:actor code="3okJJs0si">
+                            <p:name>O.K. Dude</p:name>
+                            <p:age>22</p:age>
+                            <p:gender>male</p:gender>
+                        </p:actor>
+                    </m:actors>
+                </m:movie>
+            </p:movies>
+        </p:customer>
+    </s:customers>
+</s:store>
+XML;
+
+    private $xmlMissingEndNode = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<s:store xmlns:s="http://sabre-test-set.com/Store"
+         xmlns:p="http://sabre-test-set.com/Person"
+         xmlns:b="http://sabre-test-set.com/Book"
+         xmlns:m="http://sabre-test-set.com/Movie">
+    <s:name>Awesome Shop Inc.</s:name>
+    <s:customers>
+        <p:customer code="dKje98">
+            <p:name>K.M. Johnson</p:name>
+            <p:age>33</p:age>
+            <p:gender>male</p:gender>
+            <p:books>
+                <b:book code="9488884889-33">
+                    <b:title>Boring story oversees</b:title>
+                    <b:year>1988</b:year>
+                    <b:genre>roman</b:genre>
+                    <b:author code="doj883jAA">
+                        <p:name>M.R. Lame</p:name>
+                        <p:gender>male</p:gender>
+                    </b:author>
+                    <b:publisher code="ldsKDjhn3">
+                        <p:name>C.A. Wulff</p:name>
+                        <p:age>44</p:age>
+                        <p:gender>female</p:gender>
+                </b:book>
+            </p:books>
+        </p:customer>
+        <p:customer code="kdKK9o2L">
+            <p:name>L.O. Lolsson</p:name>
+            <p:age>42</p:age>
+            <p:gender>female</p:gender>
+            <p:movies>
+                <m:movie>
+                    <m:title>Robin Hood and the wrath of the seven midgets.</m:title>
+                    <m:year>1999</m:year>
+                    <m:genre>action</m:genre>
+                    <m:actors>
+                        <p:actor code="3okJJs0si">
+                            <p:name>O.K. Dude</p:name>
+                            <p:age>22</p:age>
+                            <p:gender>male</p:gender>
+                        </p:actor>
+                    </m:actors>
+                </m:movie>
+            </p:movies>
+        </p:customer>
+    </s:customers>
+</s:store>
+XML;
+
+    private $xmlWithInvalidNodes = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<s:store xmlns:s="http://sabre-test-set.com/Store"
+         xmlns:p="http://sabre-test-set.com/Person"
+         xmlns:b="http://sabre-test-set.com/Book"
+         xmlns:m="http://sabre-test-set.com/Movie">
+    <s:name>Awesome Shop Inc.</s:name>
+    <s:customers>
+        <p:customer code="dKje98">
+            <p:name3>K.M. Johnson</p:name3>
+            <p:age>33</p:age>
+            <p:gender>male</p:gender>
+            <p:books>
+                <b:book code="9488884889-33">
+                    <b:title>Boring story oversees</b:title>
+                    <b:year>1988</b:year>
+                    <b:genre>roman</b:genre>
+                    <b:author code="doj883jAA">
+                        <p:name>M.R. Lame</p:name>
+                        <p:gender>male</p:gender>
+                    </b:author>
+                    <b:publisher code="ldsKDjhn3">
+                        <p:name>C.A. Wulff</p:name>
+                        <p:age>44</p:age>
+                        <p:gender>female</p:gender>
+                    </b:publisher>
+                </b:book>
+            </p:books>
+        </p:customer>
+        <p:customer code="kdKK9o2L">
+            <p:name>L.O. Lolsson</p:name>
+            <p:age>42</p:age>
+            <p:gender>female</p:gender>
+            <p:movies>
+                <m:movie>
+                    <m:title>Robin Hood and the wrath of the seven midgets.</m:title>
+                    <m:year>1999</m:year>
+                    <m:genre>action</m:genre>
+                    <m:actors>
+                        <p:actor code="3okJJs0si">
+                            <p:name>O.K. Dude</p:name>
+                            <p:age>22</p:age>
+                            <p:gender>male</p:gender>
+                        </p:actor>
+                    </m:actors>
+                </m:movie>
+            </p:movies>
+        </p:customer>
+    </s:customers>
+</s:store>
+XML;
+
+    private $xmlValidDocument = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<s:store xmlns:s="http://sabre-test-set.com/Store"
+         xmlns:p="http://sabre-test-set.com/Person"
+         xmlns:b="http://sabre-test-set.com/Book"
+         xmlns:m="http://sabre-test-set.com/Movie">
+    <s:name>Awesome Shop Inc.</s:name>
+    <s:customers>
+        <p:customer code="dKje98">
+            <p:name>K.M. Johnson</p:name>
+            <p:age>33</p:age>
+            <p:gender>male</p:gender>
+            <p:books>
+                <b:book code="9488884889-33">
+                    <b:title>Boring story oversees</b:title>
+                    <b:year>1988</b:year>
+                    <b:genre>roman</b:genre>
+                    <b:author code="doj883jAA">
+                        <p:name>M.R. Lame</p:name>
+                        <p:age>22</p:age>
+                        <p:gender>male</p:gender>
+                    </b:author>
+                    <b:publisher code="ldsKDjhn3">
+                        <p:name>C.A. Wulff</p:name>
+                        <p:age>44</p:age>
+                        <p:gender>female</p:gender>
+                    </b:publisher>
+                </b:book>
+            </p:books>
+        </p:customer>
+        <p:customer code="kdKK9o2L">
+            <p:name>L.O. Lolsson</p:name>
+            <p:age>42</p:age>
+            <p:gender>female</p:gender>
+            <p:movies>
+                <m:movie>
+                    <m:title>Robin Hood and the wrath of the seven midgets.</m:title>
+                    <m:year>1999</m:year>
+                    <m:genre>action</m:genre>
+                    <m:actors>
+                        <p:actor code="3okJJs0si">
+                            <p:name>O.K. Dude</p:name>
+                            <p:age>22</p:age>
+                            <p:gender>male</p:gender>
+                        </p:actor>
+                    </m:actors>
+                    <m:bestseller />
+                </m:movie>
+            </p:movies>
+        </p:customer>
+    </s:customers>
+</s:store>
+XML;
+
+    private $xmlMalformedStartTag = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<s:store xmlns:s="http://sabre-test-set.com/Store"
+         xmlns:p="http://sabre-test-set.com/Person"
+         xmlns:b="http://sabre-test-set.com/Book"
+         xmlns:m="http://sabre-test-set.com/Movie">
+    <s:name>Awesome Shop Inc.</s:name>
+    <s:customers>
+        <p:customer code="dKje98">
+            <p:name>K.M. Johnson</p:name>
+            <p:age>33</p:age>
+            <p:gend er>male</p:gender>
+            <p:books>
+                <b:book code="9488884889-33">
+                    <b:title>Boring story oversees</b:title>
+                    <b:year>1988</b:year>
+                    <b:genre>roman</b:genre>
+                    <b:author code="doj883jAA">
+                        <p:name>M.R. Lame</p:name>
+                        <p:age>22</p:age>
+                        <p:gender>male</p:gender>
+                    </b:author>
+                    <b:publisher code="ldsKDjhn3">
+                        <p:name>C.A. Wulff</p:name>
+                        <p:age>44</p:age>
+                        <p:gender>female</p:gender>
+                    </b:publisher>
+                </b:book>
+            </p:books>
+        </p:customer>
+    </s:customers>
+</s:store>
+XML;
+    private $xmlMalformedEndTag = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<s:store xmlns:s="http://sabre-test-set.com/Store"
+         xmlns:p="http://sabre-test-set.com/Person"
+         xmlns:b="http://sabre-test-set.com/Book"
+         xmlns:m="http://sabre-test-set.com/Movie">
+    <s:name>Awesome Shop Inc.</s:name>
+    <s:customers>
+        <p:customer code="kdKK9o2L">
+            <p:name>L.O. Lolsson</p:name>
+            <p:age>42</p:age>
+            <p:gender>female</p:gender>
+            <p:movies>
+                <m:movie>
+                    <m:title>Robin Hood and the wrath of the seven midgets.</m:title>
+                    <m:year>1999</m:ye ar>
+                    <m:genre>action</m:genre>
+                    <m:actors>
+                        <p:actor code="3okJJs0si">
+                            <p:name>O.K. Dude</p:name>
+                            <p:age>22</p:age>
+                            <p:gender>male</p:gender>
+                        </p:actor>
+                    </m:actors>
+                    <m:bestseller />
+                </m:movie>
+            </p:movies>
+        </p:customer>
+    </s:customers>
+</s:store>
+XML;
+
+    private $xmlMalformedQuotes = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<s:store xmlns:s="http://sabre-test-set.com/Store"
+         xmlns:p="http://sabre-test-set.com/Person"
+         xmlns:b="http://sabre-test-set.com/Book"
+         xmlns:m="http://sabre-test-set.com/Movie">
+    <s:name>Awesome Shop Inc.</s:name>
+    <s:customers>
+        <p:customer code="kdKK9o2L">
+            <p:name>L.O. Lolsson</p:name>
+            <p:age>42</p:age>
+            <p:gender>female</p:gender>
+            <p:movies>
+                <m:movie>
+                    <m:title>Robin Hood and the wrath of the seven midgets.</m:title>
+                    <m:year>1999</m:year>
+                    <m:genre>action</m:genre>
+                    <m:actors>
+                        <p:actor code="3okJJs0si>
+                            <p:name>O.K. Dude</p:name>
+                            <p:age>22</p:age>
+                            <p:gender>male</p:gender>
+                        </p:actor>
+                    </m:actors>
+                    <m:bestseller />
+                </m:movie>
+            </p:movies>
+        </p:customer>
+    </s:customers>
+</s:store>
+XML;
+
+
+}

--- a/tests/Sabre/Xml/ParserTest.php
+++ b/tests/Sabre/Xml/ParserTest.php
@@ -125,10 +125,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     function testParserShouldHandleMissingStartTag()
     {
-        // Register a tick function
-        register_tick_function(function() {
-            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed node...");
-        });
+        // Not supported on HHVM. Not registering the tick function will lead to an eternal loop on HHVM if the test fails.
+        // But at least the test will run as long as they succeed. That's better than nothing or an exception.
+        if (function_exists('register_tick_function')) {
+            // Register tick function
+            register_tick_function(function() {
+                throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the missing start tag...");
+            });
+        }
+
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
         declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
@@ -153,10 +158,14 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     function testParserShouldHandleMissingEndTag()
     {
-        // Register a tick function
-        register_tick_function(function() {
-            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed node...");
-        });
+        // Not supported on HHVM. Not registering the tick function will lead to an eternal loop on HHVM if the test fails.
+        // But at least the test will run as long as they succeed. That's better than nothing or an exception.
+        if (function_exists('register_tick_function')) {
+            // Register tick function
+            register_tick_function(function() {
+                throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the missing end tag...");
+            });
+        }
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
         declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
@@ -180,10 +189,14 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     function testParserShouldHandleMalformedStartTag()
     {
-        // Register a tick function
-        register_tick_function(function() {
-            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed start tag...");
-        });
+        // Not supported on HHVM. Not registering the tick function will lead to an eternal loop on HHVM if the test fails.
+        // But at least the test will run as long as they succeed. That's better than nothing or an exception.
+        if (function_exists('register_tick_function')) {
+            // Register tick function
+            register_tick_function(function() {
+                throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed start tag...");
+            });
+        }
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
         declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
@@ -207,10 +220,14 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     function testParserShouldHandleMalformedEndTag()
     {
-        // Register a tick function
-        register_tick_function(function() {
-            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed end tag...");
-        });
+        // Not supported on HHVM. Not registering the tick function will lead to an eternal loop on HHVM if the test fails.
+        // But at least the test will run as long as they succeed. That's better than nothing or an exception.
+        if (function_exists('register_tick_function')) {
+            // Register tick function
+            register_tick_function(function() {
+                throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed end tag...");
+            });
+        }
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
         declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
@@ -234,10 +251,14 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     function testParserShouldHandleMalformedQuotes()
     {
-        // Register a tick function
-        register_tick_function(function() {
-            throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed quotes...");
-        });
+        // Not supported on HHVM. Not registering the tick function will lead to an eternal loop on HHVM if the test fails.
+        // But at least the test will run as long as they succeed. That's better than nothing or an exception.
+        if (function_exists('register_tick_function')) {
+            // Register tick function
+            register_tick_function(function() {
+                throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed quotes...");
+            });
+        }
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
         declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)

--- a/tests/Sabre/Xml/ParserTest.php
+++ b/tests/Sabre/Xml/ParserTest.php
@@ -2,6 +2,20 @@
 
 namespace Sabre\Xml;
 
+/**
+ * Test the XML reader.
+ * -Test with valid document
+ * -Test XML schema validation
+ * -Test invalid documents (missing start and end tag, malformed start and end tag and malformed quotes)
+ *
+ *
+ * PHP version 5
+ *
+ * Class ParserTest
+ * @author     Daan Biesterbos <daanbiesterbos@gmail.com>
+ * @license http://sabre.io/license/ Modified BSD License
+ * @since     1.0.0
+ */
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Sabre/Xml/ParserTest.php
+++ b/tests/Sabre/Xml/ParserTest.php
@@ -98,9 +98,8 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             $reader->parse();
         } catch (LibXMLException $e) {
             $failed = true;
-        } finally {
-            $this->assertTrue($failed, 'The parser should have failed. The element "name3" is invalid.');
         }
+        $this->assertTrue($failed, 'The parser should have failed. The element "name3" is invalid.');
     }
 
     /**
@@ -117,10 +116,8 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         } catch (LibXMLException $e) {
             echo $e->getMessage() . PHP_EOL;
             $failed = true;
-        } finally {
-            $this->assertFalse($failed, 'The parser should not have failed. The given XML is valid.');
         }
-
+        $this->assertFalse($failed, 'The parser should not have failed. The given XML is valid.');
     }
 
     /**
@@ -173,10 +170,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             $trappedInEternalLoop = false;
         } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
-        } finally {
-            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
-            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
         }
+        $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+        $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
     }
 
     /**
@@ -201,10 +197,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             $trappedInEternalLoop = false;
         } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
-        } finally {
-            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
-            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
         }
+        $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+        $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
     }
 
     /**
@@ -229,10 +224,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             $trappedInEternalLoop = false;
         } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
-        } finally {
-            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
-            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
         }
+        $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+        $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
     }
 
     /**
@@ -257,10 +251,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             $trappedInEternalLoop = false;
         } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
-        } finally {
-            $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
-            $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
         }
+        $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
+        $this->assertFalse($trappedInEternalLoop, "Eternal loop detected!");
     }
 
 

--- a/tests/Sabre/Xml/ParserTest.php
+++ b/tests/Sabre/Xml/ParserTest.php
@@ -1,6 +1,6 @@
 <?php
-namespace Sabre\Xml;
 
+namespace Sabre\Xml;
 
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,7 +12,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      * - Test elements with child nodes
      * - Test element without child nodes and attributes ( <movie:bestseller /> )
      */
-    public function testParserShouldSucceed()
+    function testParserShouldSucceed()
     {
         $reader = new Reader();
         $reader->XML($this->xmlValidDocument);
@@ -74,7 +74,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      * Test if the schema validation works. When enabled each node is validated on the fly.
      * By calling the parse method the whole tree processed and thus we should get an exception.
      */
-    public function testParserShouldFailSchemaValidation()
+    function testParserShouldFailSchemaValidation()
     {
         $reader = new Reader();
         $reader->XML($this->xmlWithInvalidNodes);
@@ -82,7 +82,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $failed = false;
         try{
             $reader->parse();
-        } catch(LibXMLException $e) {
+        } catch (LibXMLException $e) {
             $failed = true;
         } finally {
             $this->assertTrue($failed, 'The parser should have failed. The element "name3" is invalid.');
@@ -92,7 +92,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     /**
      * Ensure that the validation works for valid documents
      */
-    public function testParserShouldPassSchemaValidation()
+    function testParserShouldPassSchemaValidation()
     {
         $reader = new Reader();
         $reader->XML($this->xmlValidDocument);
@@ -100,7 +100,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $failed = false;
         try{
             $reader->parse();
-        } catch(LibXMLException $e) {
+        } catch (LibXMLException $e) {
             echo $e->getMessage() . PHP_EOL;
             $failed = true;
         } finally {
@@ -112,24 +112,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     /**
      * Test if the parser can handle missing start tags.
      */
-    public function testParserShouldHandleMissingStartTag()
+    function testParserShouldHandleMissingStartTag()
     {
         // Register a tick function
-        register_tick_function(function(){
+        register_tick_function(function() {
             throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed node...");
         });
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
-        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
         $reader = new Reader();
         $reader->XML($this->xmlMissingStartNode);
         $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
         $trappedInEternalLoop = null;
         try{
             $reader->parse();
-        } catch(ParseException $e) {
+        } catch (ParseException $e) {
             $trappedInEternalLoop = false;
-        } catch(\LogicException $e) {
+        } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
         }
 
@@ -140,24 +140,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     /**
      * Test if the parser can handle missing end tags
      */
-    public function testParserShouldHandleMissingEndTag()
+    function testParserShouldHandleMissingEndTag()
     {
         // Register a tick function
-        register_tick_function(function(){
+        register_tick_function(function() {
             throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed node...");
         });
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
-        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
         $reader = new Reader();
         $reader->XML($this->xmlMissingEndNode);
         $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
         $trappedInEternalLoop = null;
         try{
             $reader->parse();
-        } catch(ParseException $e) {
+        } catch (ParseException $e) {
             $trappedInEternalLoop = false;
-        } catch(\LogicException $e) {
+        } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
         } finally {
             $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
@@ -168,24 +168,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     /**
      * Test if the parser can handle malformed start tags
      */
-    public function testParserShouldHandleMalformedStartTag()
+    function testParserShouldHandleMalformedStartTag()
     {
         // Register a tick function
-        register_tick_function(function(){
+        register_tick_function(function() {
             throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed start tag...");
         });
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
-        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
         $reader = new Reader();
         $reader->XML($this->xmlMalformedStartTag);
         $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
         $trappedInEternalLoop = null;
         try{
             $reader->parse();
-        } catch(ParseException $e) {
+        } catch (ParseException $e) {
             $trappedInEternalLoop = false;
-        } catch(\LogicException $e) {
+        } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
         } finally {
             $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
@@ -196,25 +196,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     /**
      * Test if the parser can handle malformed end tags
      */
-    public function testParserShouldHandleMalformedEndTag()
+    function testParserShouldHandleMalformedEndTag()
     {
         // Register a tick function
-        register_tick_function(function(){
+        register_tick_function(function() {
             throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed end tag...");
         });
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
-        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
         $reader = new Reader();
-        //$reader->setValidationEnabled(true);
         $reader->XML($this->xmlMalformedEndTag);
         $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
         $trappedInEternalLoop = null;
         try{
             $reader->parse();
-        } catch(ParseException $e) {
+        } catch (ParseException $e) {
             $trappedInEternalLoop = false;
-        } catch(\LogicException $e) {
+        } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
         } finally {
             $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");
@@ -225,24 +224,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     /**
      * Test if the parser can handle malformed end tags
      */
-    public function testParserShouldHandleMalformedQuotes()
+    function testParserShouldHandleMalformedQuotes()
     {
         // Register a tick function
-        register_tick_function(function(){
+        register_tick_function(function() {
             throw new \LogicException("Test failed. The reader seems to be trapped in a eternal loop. Failed to recognize the malformed quotes...");
         });
 
         // Parse elements, use tick counter to break out of eternal loop and throw an exception
-        declare(ticks=10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
+        declare (ticks = 10000000); // Don't use low values, apparently phpunit is also using ticks and will collide with low values)
         $reader = new Reader();
         $reader->XML($this->xmlMalformedQuotes);
         $reader->setSchema(__DIR__ . '/../../schema/Store.xsd');
         $trappedInEternalLoop = null;
         try{
             $reader->parse();
-        } catch(ParseException $e) {
+        } catch (ParseException $e) {
             $trappedInEternalLoop = false;
-        } catch(\LogicException $e) {
+        } catch (\LogicException $e) {
             $trappedInEternalLoop = true;
         } finally {
             $this->assertNotNull($trappedInEternalLoop, "That's not good. The parser should have failed!");

--- a/tests/schema/Book.xsd
+++ b/tests/schema/Book.xsd
@@ -1,0 +1,66 @@
+<xs:schema targetNamespace="http://sabre-test-set.com/Book"
+           xmlns:book="http://sabre-test-set.com/Book"
+           xmlns:person="http://sabre-test-set.com/Person"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+
+    <xs:import schemaLocation="Movie.xsd" namespace="http://sabre-test-set.com/Movie" />
+    <xs:import schemaLocation="Person.xsd" namespace="http://sabre-test-set.com/Person" />
+
+    <!--+====================================================================================================+-->
+    <!--+ Simple types                                                                                       +-->
+    <!--+====================================================================================================+-->
+
+    <xs:simpleType name="YearType">
+        <xs:restriction base="xs:unsignedInt">
+            <xs:minInclusive value="1900" />
+            <xs:maxExclusive value="2100" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="GenreType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="thriller" />
+            <xs:enumeration value="roman" />
+            <xs:enumeration value="art" />
+            <xs:enumeration value="history" />
+            <xs:enumeration value="detective" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--+====================================================================================================+-->
+    <!--+ Complex types                                                                                      +-->
+    <!--+====================================================================================================+-->
+
+    <xs:complexType name="BookType">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element ref="book:title" minOccurs="0" />
+            <xs:element ref="book:year" minOccurs="0" />
+            <xs:element ref="book:genre" minOccurs="0" />
+            <xs:element ref="book:author" minOccurs="0" />
+            <xs:element ref="book:publisher" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="code" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="BookCollection">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element ref="book:book" />
+        </xs:sequence>
+    </xs:complexType>
+
+
+    <!--+====================================================================================================+-->
+    <!--+ Elements                                                                                           +-->
+    <!--+====================================================================================================+-->
+    <xs:element name="book" type="book:BookType" nillable="false" />
+    <xs:element name="publisher" type="person:PublisherType" nillable="false" />
+    <xs:element name="title" type="xs:string" nillable="false" />
+    <xs:element name="year" type="book:YearType" />
+    <xs:element name="genre" type="book:GenreType" />
+    <xs:element name="author" type="person:AuthorType" />
+
+
+
+</xs:schema>

--- a/tests/schema/Movie.xsd
+++ b/tests/schema/Movie.xsd
@@ -1,0 +1,66 @@
+<xs:schema targetNamespace="http://sabre-test-set.com/Movie"
+           xmlns:movie="http://sabre-test-set.com/Movie"
+           xmlns:person="http://sabre-test-set.com/Person"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+    <xs:import schemaLocation="Book.xsd" namespace="http://sabre-test-set.com/Book" />
+    <xs:import schemaLocation="Person.xsd" namespace="http://sabre-test-set.com/Person" />
+
+
+    <!--+====================================================================================================+-->
+    <!--+ Simple types                                                                                       +-->
+    <!--+====================================================================================================+-->
+
+    <xs:simpleType name="YearType">
+        <xs:restriction base="xs:unsignedInt">
+            <xs:minInclusive value="1900" />
+            <xs:maxExclusive value="2100" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="GenreType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="thriller" />
+            <xs:enumeration value="comedy" />
+            <xs:enumeration value="action" />
+            <xs:enumeration value="horror" />
+            <xs:enumeration value="detective" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--+====================================================================================================+-->
+    <!--+ Complex types                                                                                      +-->
+    <!--+====================================================================================================+-->
+
+    <xs:complexType name="MovieType">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element ref="movie:title" />
+            <xs:element ref="movie:year"  />
+            <xs:element ref="movie:genre" />
+            <xs:element ref="movie:actors" />
+            <xs:element ref="movie:bestseller" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="MovieCollection">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element ref="movie:movie" />
+        </xs:sequence>
+    </xs:complexType>
+
+
+
+    <!--+====================================================================================================+-->
+    <!--+ Elements                                                                                           +-->
+    <!--+====================================================================================================+-->
+    <xs:element name="movie" type="movie:MovieType" nillable="false" />
+    <xs:element name="title" type="xs:string" nillable="false" />
+    <xs:element name="year" type="movie:YearType" />
+    <xs:element name="bestseller" type="xs:anyType" nillable="true" />
+    <xs:element name="genre" type="movie:GenreType" />
+    <xs:element name="actors" type="person:ActorCollection" />
+
+
+
+</xs:schema>

--- a/tests/schema/Person.xsd
+++ b/tests/schema/Person.xsd
@@ -1,0 +1,117 @@
+<xs:schema targetNamespace="http://sabre-test-set.com/Person"
+           xmlns:person="http://sabre-test-set.com/Person"
+           xmlns:movie="http://sabre-test-set.com/Movie"
+           xmlns:book="http://sabre-test-set.com/Book"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+    <xs:import schemaLocation="Book.xsd" namespace="http://sabre-test-set.com/Book" />
+    <xs:import schemaLocation="Movie.xsd" namespace="http://sabre-test-set.com/Movie" />
+
+
+    <!--+====================================================================================================+-->
+    <!--+ Simple types                                                                                       +-->
+    <!--+====================================================================================================+-->
+
+    <xs:simpleType name="AgeType">
+        <xs:restriction base="xs:unsignedInt">
+            <xs:minInclusive value="0" />
+            <xs:maxExclusive value="200" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="GenderType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="male" />
+            <xs:enumeration value="female" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--+====================================================================================================+-->
+    <!--+ Complex types                                                                                      +-->
+    <!--+====================================================================================================+-->
+
+    <xs:complexType name="PersonType">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element ref="person:name" />
+            <xs:element ref="person:age"  minOccurs="0" />
+            <xs:element ref="person:gender" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="code" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="AuthorType">
+        <xs:complexContent>
+            <xs:extension base="person:PersonType">
+                <xs:sequence>
+                    <xs:element ref="person:publishers" minOccurs="0" />
+                    <xs:element ref="person:books" minOccurs="0" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="PublisherType">
+        <xs:complexContent>
+            <xs:extension base="person:PersonType">
+
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ActorType">
+        <xs:complexContent>
+            <xs:extension base="person:PersonType">
+                <xs:sequence minOccurs="0">
+                    <xs:element ref="person:movies" minOccurs="0" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="CustomerType">
+        <xs:complexContent>
+            <xs:extension base="person:PersonType">
+                <xs:sequence>
+                    <xs:element ref="person:movies" minOccurs="0" />
+                    <xs:element ref="person:books" minOccurs="0" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="PublisherCollection">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element ref="person:publisher" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="ActorCollection">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element ref="person:actor" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="CustomerCollection">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element ref="person:customer" />
+        </xs:choice>
+    </xs:complexType>
+
+
+    <!--+====================================================================================================+-->
+    <!--+ Elements                                                                                           +-->
+    <!--+====================================================================================================+-->
+    <xs:element name="name" type="xs:string" nillable="false" />
+    <xs:element name="age" type="person:AgeType" />
+    <xs:element name="gender" type="person:GenderType" />
+    <xs:element name="actor" type="person:ActorType" />
+    <xs:element name="customer" type="person:CustomerType" />
+    <xs:element name="books" type="book:BookCollection" />
+    <xs:element name="publishers" type="person:PublisherCollection" />
+    <xs:element name="publisher" type="person:PublisherType" />
+    <xs:element name="movies" type="movie:MovieCollection" />
+
+
+
+</xs:schema>

--- a/tests/schema/Store.xsd
+++ b/tests/schema/Store.xsd
@@ -1,0 +1,31 @@
+<xs:schema targetNamespace="http://sabre-test-set.com/Store"
+           xmlns:store="http://sabre-test-set.com/Store"
+           xmlns:person="http://sabre-test-set.com/Person"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+    <xs:import schemaLocation="Book.xsd" namespace="http://sabre-test-set.com/Book" />
+    <xs:import schemaLocation="Person.xsd" namespace="http://sabre-test-set.com/Person" />
+    <xs:import schemaLocation="Movie.xsd" namespace="http://sabre-test-set.com/Movie" />
+
+    <!--+====================================================================================================+-->
+    <!--+ Complex types                                                                                      +-->
+    <!--+====================================================================================================+-->
+
+    <xs:complexType name="StoreType">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element ref="store:name" />
+            <xs:element ref="store:customers" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <!--+====================================================================================================+-->
+    <!--+ Elements                                                                                           +-->
+    <!--+====================================================================================================+-->
+    <xs:element name="name" type="xs:string" />
+    <xs:element name="customers" type="person:CustomerCollection" />
+    <xs:element name="store" type="store:StoreType" />
+
+
+
+</xs:schema>


### PR DESCRIPTION
Hi, 
I was facing some instability issues regarding invalid XML documents. I would expect an exception but instead the Reader will (in some cases) attempt to keep parsing the same node eternally. I fixed this by adding a validation step.  The XMLReader::isValid may not be backward compatible so I made the validation step optional. Altough I did not validate this thouroughly it seems like this method will only work when the something like a XSD, DTD etc is in place.  Either way. The feature is optional, so this change should not be problematic. 

Update:
The validation did not fix all scenario's. The new solution does. Basically we now check if libxml has fatal errors on each iteration. I did not implement this as a optional feature since it ensures that your application will not crash when invalid XML is provided. 