### PR TITLE
Disable entity loader

### DIFF
--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -56,6 +56,7 @@ class Reader extends XMLReader {
      */
     function parse() {
 
+        $previousEntityState = libxml_disable_entity_loader(true);
         $previousSetting = libxml_use_internal_errors(true);
 
         // Really sorry about the silence operator, seems like I have no
@@ -70,6 +71,7 @@ class Reader extends XMLReader {
         $errors = libxml_get_errors();
         libxml_clear_errors();
         libxml_use_internal_errors($previousSetting);
+        libxml_disable_entity_loader($previousEntityState);
 
         if ($errors) {
             throw new LibXMLException($errors);


### PR DESCRIPTION
Otherwise it is possible to perform requests to other domains, gaining access to local file resources seems not possible.

Following XML will perform a request to http://owncloud.org when the loader is enabled which is especially of relevance due to https://bugs.php.net/bug.php?id=64938.
```xml
<?xml version="1.0" encoding="utf-8" standalone='no'?>
<!DOCTYPE books [
<!ENTITY % e1fe9 SYSTEM "http://owncloud.org">%e1fe9; ]>
<books
    xmlns="http://example.org/books">
    <book>
        <title>Snow Crash</title>
        <author>Neil Stephenson</author>
    </book>
    <book>
        <title>Dune</title>
        <author>Frank Herbert</author>
    </book>
</books>
```

@evert THX