### PR TITLE
Improved phpdocs return type in Reader::parseAttributes

### DIFF
--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -262,7 +262,7 @@ class Reader extends XMLReader {
      * short keys. If they are defined on a different namespace, the attribute
      * name will be retured in clark-notation.
      *
-     * @return void
+     * @return array
      */
     function parseAttributes() {
 


### PR DESCRIPTION
Corrected phpdocs return type of Sabre\Xml\Reader::parseAttributes so my IDE stops whining about.