### PR TITLE
Automatically support VO properties that are specified as arrays.

### DIFF
--- a/lib/deserializers.php
+++ b/lib/deserializers.php
@@ -182,13 +182,19 @@ function valueObject(Reader $reader, $className, $namespace) {
         return $valueObject;
     }
 
+    $defaultProperties = get_class_vars($className);
+
     $reader->read();
     do {
 
         if ($reader->nodeType === Reader::ELEMENT && $reader->namespaceURI == $namespace) {
 
             if (property_exists($valueObject, $reader->localName)) {
-                $valueObject->{$reader->localName} = $reader->parseCurrentElement()['value'];
+                if (is_array($defaultProperties[$reader->localName])) {
+                    $valueObject->{$reader->localName}[] = $reader->parseCurrentElement()['value'];
+                } else {
+                    $valueObject->{$reader->localName} = $reader->parseCurrentElement()['value'];
+                }
             } else {
                 // Ignore property
                 $reader->next();

--- a/tests/Sabre/Xml/DeserializersTest.php
+++ b/tests/Sabre/Xml/DeserializersTest.php
@@ -135,11 +135,57 @@ XML;
 
     }
 
+    function testDeserializeValueObjectAutoArray() {
+
+        $input = <<<XML
+<?xml version="1.0"?>
+<foo xmlns="urn:foo">
+   <firstName>Harry</firstName>
+   <lastName>Turtle</lastName>
+   <link>http://example.org/</link>
+   <link>http://example.net/</link>
+</foo>
+XML;
+
+        $reader = new Reader();
+        $reader->xml($input);
+        $reader->elementMap = [
+            '{urn:foo}foo' => function(Reader $reader) {
+                return valueObject($reader, 'Sabre\\Xml\\Deserializer\\TestVo', 'urn:foo');
+            }
+        ];
+
+        $output = $reader->parse();
+
+        $vo = new TestVo();
+        $vo->firstName = 'Harry';
+        $vo->lastName = 'Turtle';
+        $vo->link = [
+            'http://example.org/',
+            'http://example.net/',
+        ];
+
+
+        $expected = [
+            'name'       => '{urn:foo}foo',
+            'value'      => $vo,
+            'attributes' => []
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $output
+        );
+
+    }
+
 }
 
 class TestVo {
 
     public $firstName;
     public $lastName;
+
+    public $link = [];
 
 }


### PR DESCRIPTION
This is a feature for VO's such as this:

    class VO {

       public $foo = [];

    }

Specifying the empty array as the default will cause the parser to
assume that foo may appear more than once and append elements to the
array.

cc: @staabm 