### PR TITLE
Cache namespaces parsed from clark notation

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -266,16 +266,21 @@ class Service {
      * @return array
      */
     static function parseClarkNotation($str) {
+        static $cache = [];
 
-        if (!preg_match('/^{([^}]*)}(.*)$/', $str, $matches)) {
-            throw new \InvalidArgumentException('\'' . $str . '\' is not a valid clark-notation formatted string');
+        if (!isset($cache[$str])) {
+
+            if (!preg_match('/^{([^}]*)}(.*)$/', $str, $matches)) {
+                throw new \InvalidArgumentException('\'' . $str . '\' is not a valid clark-notation formatted string');
+            }
+
+            $cache[$str] = [
+                $matches[1],
+                $matches[2]
+            ];
         }
 
-        return [
-            $matches[1],
-            $matches[2]
-        ];
-
+        return $cache[$str];
     }
 
     /**


### PR DESCRIPTION
When serializing large xml documents the cost parsing of the namespaces from clark notation becomes a significant portion (>10%) of the serialization cost.
Since most xml documents will only use a fairly small number of xml elements we're better of keeping the parsed version of the namespace/element around for reuse.

This saves doing a regex (and some memory allocations) for each element we serialize

[comparison](https://blackfire.io/profiles/compare/4449f8f7-abbc-4b7d-89a4-a3770e75b053/graph)

cc @evert 