### PR TITLE
Disable xdebug for composer install to speedup build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ script:
   - ./bin/phpunit --configuration tests/phpunit.xml.dist
   - ./bin/sabre-cs-fixer fix . --dry-run --diff
 
-before_script: composer install
+before_script:
+  - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+  - composer install


### PR DESCRIPTION
We dont use xdebug features in travis, therefore disabling it which speeds up build considerably.