### PR TITLE
restore reader-context in early-return paths

### DIFF
--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -142,7 +142,12 @@ class Reader extends XMLReader {
         // choice. See:
         //
         // https://bugs.php.net/bug.php?id=64230
-        if (!@$this->read()) return false;
+        if (!@$this->read()) {
+            if (!is_null($elementMap)) {
+                $this->popContext();
+            }
+            return false;
+        }
 
         while (true) {
 
@@ -152,6 +157,9 @@ class Reader extends XMLReader {
 
                 if ($errors) {
                     libxml_clear_errors();
+                    if (!is_null($elementMap)) {
+                        $this->popContext();
+                    }
                     throw new LibXMLException($errors);
                 }
             }
@@ -170,6 +178,9 @@ class Reader extends XMLReader {
                     $this->read();
                     break 2;
                 case self::NONE :
+                    if (!is_null($elementMap)) {
+                        $this->popContext();
+                    }
                     throw new ParseException('We hit the end of the document prematurely. This likely means that some parser "eats" too many elements. Do not attempt to continue parsing.');
                 default :
                     // Advance to the next element


### PR DESCRIPTION
this are edge-cases but still those should restore the proper context of the current reader.

I didnt experience a concrete problems with this but just stumbled across it while reading the code.
Thats why no unit test provided.

Feel free to close this without merging it in case you think its not worth it.