### PR TITLE
Fix: Remove empty bin section from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,6 @@
             "Sabre\\Xml\\" : "tests/Sabre/Xml/"
         }
     },
-    "bin" : [
-    ],
     "require-dev": {
         "sabre/cs": "~0.0.2",
         "phpunit/phpunit" : "*"


### PR DESCRIPTION
This PR

* [x] removes an empty `bin` section from `composer.json`