### PR TITLE
Updated keyValue deserializer

### DIFF
--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -81,15 +81,16 @@ function keyValue(Reader $reader, $namespace = null) {
                 $value = $reader->parseCurrentElement()['value'];
             }
 
-            if (is_array($values[$key])) {
-                $values[$key][] = $value;
-            }
-            elseif (array_key_exists($key, $values)) {
-                $tmp = $values[$key];
-                $values[$key] = [$tmp, $value];
+            if (!isset($values[$key])) {
+                $values[$key] = $value;
             }
             else {
-                $values[$key] = $value;
+                if (!is_array($values[$key])) {
+                    $tmp = $values[$key];
+                    $values[$key] = [$tmp];
+                }
+
+                $values[$key][] = $value;
             }
         } else {
             $reader->read();

--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -51,7 +51,8 @@ use Sabre\Xml\Reader;
  * ];
  *
  * Attributes will be removed from the top-level elements. If elements with
- * the same name appear twice in the list, only the last one will be kept.
+ * the same name appear twice in the list, an array of those elements are
+ * returned.
  *
  *
  * @param Reader $reader
@@ -73,10 +74,22 @@ function keyValue(Reader $reader, $namespace = null) {
 
         if ($reader->nodeType === Reader::ELEMENT) {
             if ($namespace !== null && $reader->namespaceURI === $namespace) {
-                $values[$reader->localName] = $reader->parseCurrentElement()['value'];
+                $key   = $reader->localName;
+                $value = $reader->parseCurrentElement()['value'];
             } else {
-                $clark = $reader->getClark();
-                $values[$clark] = $reader->parseCurrentElement()['value'];
+                $key   = $reader->getClark();
+                $value = $reader->parseCurrentElement()['value'];
+            }
+
+            if (is_array($values[$key])) {
+                $values[$key][] = $value;
+            }
+            elseif (array_key_exists($key, $values)) {
+                $tmp = $values[$key];
+                $values[$key] = [$tmp, $value];
+            }
+            else {
+                $values[$key] = $value;
             }
         } else {
             $reader->read();


### PR DESCRIPTION
XML that contains elements that have multiple occurrences are returned as an array of those elements, rather than just the last element in the list.

Given this XML:
```
<list>
    <meta>
        ...
    </meta>
    <report>
        <name/>
    </report>
    <report>
        <name/>
    </report>
    <report>
        <name/>
    </report>
    <report>
        <name/>
    </report>
</list>
```
The resulting object could be returned:
```
Sabre Object
(
    [meta] => Meta Object
        (
            ...
        )
    [report] => Array
        (
            [0] => Report Object
                (
                    [title] => Report Title
                )

            [1] => Report Object
                (
                    [title] => Report Title
                )

            [2] => Report Object
                (
                    [title] => Report Title
                )

            [3] => Report Object
                (
                    [title] => Report Title
                )

            [4] => Report Object
                (
                    [title] => Report Title
                )
```