### PR TITLE
Dependency sabre/uri for PHP5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-xmlreader" : "*",
         "ext-dom" : "*",
         "lib-libxml" : ">=2.6.20",
-        "sabre/uri" : ">=1.0,<3.0.0"
+        "sabre/uri" : ">=1.0,<1.3"
     },
     "authors" : [
         {


### PR DESCRIPTION
sabre/xml 2.0 can only be used on php7. So when you use php5, you need to fall back to sabre/xml 1.5.x, that's fine.

sabre/xml 2.0 requires: sabre/uri: >=1.0,<3.0.0
sabre/xml 1.5.x requires: sabre/uri: >=1.0,<3.0.0
sabre/uri >=1.0,<3.0.0 is currently version 2.1.0 which is also php7 only.

So installing sabre/xml 1.5.x will install the incorrect sabre/uri version. For php 5 sabre 1.5 needs to use sabre/uri 1.2.x.

In this fix I used  <1.3 assuming this will always have php 5 support.