### PR TITLE
set correct return type

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -173,7 +173,7 @@ class Service {
      * of the domain.
      *
      * @param string|array|XmlSerializable $value
-     * @return void
+     * @return string
      */
     function write(string $rootElementName, $value, string $contextUri = null) {
 


### PR DESCRIPTION
This function returns a string, but the PHPDoc comment currently says it returns void.