### PR TITLE
removed scalar strict type

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -175,7 +175,7 @@ class Service {
      * @param string|array|XmlSerializable $value
      * @return string
      */
-    function write(string $rootElementName, $value, string $contextUri = null) {
+    function write($rootElementName, $value, string $contextUri = null) {
 
         $w = $this->getWriter();
         $w->openMemory();


### PR DESCRIPTION
this method supports more types then `string` (as per phpdoc)