### PR TITLE
[master] Fix invalid PHPDocs

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -131,7 +131,9 @@ class Service {
      *
      * @param string|string[] $rootElementName
      * @param string|resource $input
-     * @return void
+     * @param string|null $contextUri
+     * @throws ParseException
+     * @return array|object|string
      */
     function expect($rootElementName, $input, string $contextUri = null) {
 


### PR DESCRIPTION
To make https://github.com/etsy/phan happy:

```
apps/dav/lib/CardDAV/SyncService.php:255 PhanNonClassMethodCall Call to method getResponses on non-class type void
apps/dav/lib/CardDAV/SyncService.php:259 PhanNonClassMethodCall Call to method getSyncToken on non-class type void
```